### PR TITLE
Added the roll movement for both players in the platformer

### DIFF
--- a/data/input-contexts/arrows.json
+++ b/data/input-contexts/arrows.json
@@ -8,6 +8,7 @@
 		] }, 
 		{ "command-name": "jump", "trigger": "KeyUp" },
 		{ "command-name": "down", "trigger": "KeyDown" },
+		{ "command-name": "roll", "trigger": "KeyRightControl" },
 		{ "command-name": "light", "trigger": "KeyL", "event": "Released" },
 		{ "command-name": "heavy", "trigger": "KeyL", "duration": 1000 },
 		{ "command-name": "use", "trigger": "KeyO" }

--- a/data/input-contexts/asdw.json
+++ b/data/input-contexts/asdw.json
@@ -8,6 +8,7 @@
 		] }, 
 		{ "command-name": "jump", "trigger": "KeyW" },
 		{ "command-name": "down", "trigger": "KeyS" },
+		{ "command-name": "roll", "trigger": "KeyX" },
 		{ "command-name": "light", "trigger": "KeyR", "event": "Released" },
 		{ "command-name": "heavy", "trigger": "KeyR", "duration": 1000 },
 		{ "command-name": "use", "trigger": "KeyE" }

--- a/source/dagger/gameplay/platformer/platformer_controller.cpp
+++ b/source/dagger/gameplay/platformer/platformer_controller.cpp
@@ -44,13 +44,6 @@ void PlatformerControllerSystem::Run()
                     sprite_.scale.x = run;
                 }
             }
-            else
-            {
-                if (char_.timeRolling >= char_.rollingTime)
-                {
-                    char_.isRolling = false;
-                }
-            }
 
             if (char_.isRolling)
             {

--- a/source/dagger/gameplay/platformer/platformer_controller.cpp
+++ b/source/dagger/gameplay/platformer/platformer_controller.cpp
@@ -31,11 +31,10 @@ void PlatformerControllerSystem::Run()
         {
             Float32 roll = input_.values.at("roll");
             Float32 run = input_.values.at("run");
-            
+
             if (roll == 1)
             {
                 char_.isRolling = true;
-                AnimatorPlay(animator_, "souls_like_knight_character:ROLL");
 
                 // Ex: If the player is pressing the left movement key and roll Key
                 // allow him to do that. Alligning the sprite_.scale.x with run variable enables
@@ -44,19 +43,27 @@ void PlatformerControllerSystem::Run()
                 {
                     sprite_.scale.x = run;
                 }
-
-                if (char_.isRolling)
+            }
+            else
+            {
+                if (char_.timeRolling >= char_.rollingTime)
                 {
-                    if (char_.timeRolling < char_.rollingTime)
-                    {
-                        sprite_.position.x += char_.rollingSpeed * sprite_.scale.x * Engine::DeltaTime();
-                        char_.timeRolling++;
-                    }
-                    else
-                    {
-                        char_.isRolling = false;
-                        char_.timeRolling = 0;
-                    }
+                    char_.isRolling = false;
+                }
+            }
+
+            if (char_.isRolling)
+            {
+                if (char_.timeRolling < char_.rollingTime)
+                {
+                    AnimatorPlay(animator_, "souls_like_knight_character:ROLL");
+                    sprite_.position.x += char_.rollingSpeed * sprite_.scale.x * Engine::DeltaTime();
+                    char_.timeRolling += Engine::DeltaTime();
+                }
+                else
+                {
+                    char_.isRolling = false;
+                    char_.timeRolling = 0;
                 }
             }
             else

--- a/source/dagger/gameplay/platformer/platformer_controller.cpp
+++ b/source/dagger/gameplay/platformer/platformer_controller.cpp
@@ -13,7 +13,7 @@ using namespace platformer;
 void PlatformerControllerSystem::OnInitialize(Registry& registry_, Entity entity_)
 {
     InputReceiver& receiver = registry_.get<InputReceiver>(entity_);
-    for (auto command : { "run", "jump", "down", "heavy", "light", "use" })
+    for (auto command : { "run", "jump", "down", "roll", "heavy", "light", "use" })
     {
         receiver.values[command] = 0;
     }
@@ -27,18 +27,50 @@ void PlatformerControllerSystem::SpinUp()
 void PlatformerControllerSystem::Run()
 {
     Engine::Registry().view<InputReceiver, Sprite, Animator, PlatformerCharacter>().each(
-        [](const InputReceiver input_, Sprite& sprite_, Animator& animator_, const PlatformerCharacter& char_)
+        [](const InputReceiver input_, Sprite& sprite_, Animator& animator_, PlatformerCharacter& char_)
         {
+            Float32 roll = input_.values.at("roll");
             Float32 run = input_.values.at("run");
-            if (run == 0)
+            
+            if (roll == 1)
             {
-                AnimatorPlay(animator_, "souls_like_knight_character:IDLE");
+                char_.isRolling = true;
+                AnimatorPlay(animator_, "souls_like_knight_character:ROLL");
+
+                // Ex: If the player is pressing the left movement key and roll Key
+                // allow him to do that. Alligning the sprite_.scale.x also enables
+                // the character to start rolling in the direction it is facing
+                if (run != 0)
+                {
+                    sprite_.scale.x = run;
+                }
+
+                if (char_.isRolling)
+                {
+                    if (char_.timeRolling < char_.rollingTime)
+                    {
+                        sprite_.position.x += char_.rollingSpeed * sprite_.scale.x * Engine::DeltaTime();
+                        char_.timeRolling++;
+                    }
+                    else
+                    {
+                        char_.isRolling = false;
+                        char_.timeRolling = 0;
+                    }
+                }
             }
             else
             {
-                AnimatorPlay(animator_, "souls_like_knight_character:RUN");
-                sprite_.scale.x = run;
-                sprite_.position.x += char_.speed * sprite_.scale.x * Engine::DeltaTime();
+                if (run == 0 && roll == 0)
+                {
+                    AnimatorPlay(animator_, "souls_like_knight_character:IDLE");
+                }
+                else
+                {
+                    AnimatorPlay(animator_, "souls_like_knight_character:RUN");
+                    sprite_.scale.x = run;
+                    sprite_.position.x += char_.speed * sprite_.scale.x * Engine::DeltaTime();
+                }
             }
         });
 }

--- a/source/dagger/gameplay/platformer/platformer_controller.cpp
+++ b/source/dagger/gameplay/platformer/platformer_controller.cpp
@@ -38,7 +38,7 @@ void PlatformerControllerSystem::Run()
                 AnimatorPlay(animator_, "souls_like_knight_character:ROLL");
 
                 // Ex: If the player is pressing the left movement key and roll Key
-                // allow him to do that. Alligning the sprite_.scale.x also enables
+                // allow him to do that. Alligning the sprite_.scale.x with run variable enables
                 // the character to start rolling in the direction it is facing
                 if (run != 0)
                 {

--- a/source/dagger/gameplay/platformer/platformer_controller.h
+++ b/source/dagger/gameplay/platformer/platformer_controller.h
@@ -13,8 +13,8 @@ namespace platformer
 		
 		bool isRolling{ false };
 		Float32 rollingSpeed{ 25.0f };
-		UInt8 rollingTime{ 5 };
-		UInt8 timeRolling{ 0 };
+		Float32 rollingTime{ 0.75f };
+		Float32 timeRolling{ 0.0f };
 	};
 
 	class PlatformerControllerSystem

--- a/source/dagger/gameplay/platformer/platformer_controller.h
+++ b/source/dagger/gameplay/platformer/platformer_controller.h
@@ -10,6 +10,11 @@ namespace platformer
 	struct PlatformerCharacter
 	{
 		int speed{ 1 };
+		
+		bool isRolling{ false };
+		Float32 rollingSpeed{ 25.0f };
+		UInt8 rollingTime{ 5 };
+		UInt8 timeRolling{ 0 };
 	};
 
 	class PlatformerControllerSystem


### PR DESCRIPTION
Players can now use the roll movement. WASD player rolls using the X key, while Arrows player rolls using the right ctrl key.