### PR TITLE
Custom collision system, players can't go through each other.

### DIFF
--- a/source/dagger/gameplay/platformer/platformer_collision.cpp
+++ b/source/dagger/gameplay/platformer/platformer_collision.cpp
@@ -1,0 +1,129 @@
+#include "platformer_collision.h"
+
+#include "core/engine.h"
+#include "core/game/transforms.h"
+
+#include "gameplay/platformer/platformer_controller.h"
+
+using namespace dagger;
+using namespace platformer;
+
+void PlatformerCollisionSystem::Run()
+{
+    auto view = Engine::Registry().view<PlatformerCollision, PlatformerCharacter, Transform>();
+    auto it = view.begin();
+
+    while (it != view.end())
+    {
+        auto& collision = view.get<PlatformerCollision>(*it);
+        auto& character = view.get<PlatformerCharacter>(*it);
+        auto& transform = view.get<Transform>(*it);
+
+        auto it2 = view.begin();
+        while (it2 != view.end())
+        {
+            auto& col = view.get<PlatformerCollision>(*it2);
+            auto& ch = view.get<PlatformerCharacter>(*it2);
+            auto& tr = view.get<Transform>(*it2);
+
+            if (ch.id != character.id)
+            {
+                // Perform the collision check
+                CollisionInfo collisionInfo = collision.GetCollisionInfo(transform.position, col, tr.position);
+
+                if (collisionInfo.hasCollided)
+                {
+                    if (collision.collidesWith[col.entityType])
+                    {
+                        if (collision.entityType == PlatformerCollisionSystem::playerID)
+                        {
+                            if (col.entityType == PlatformerCollisionSystem::terrainID ||
+                                col.entityType == PlatformerCollisionSystem::playerID)
+                            {
+                                LimitPlayerMovement(character, collisionInfo);
+                            }
+                        }
+
+                    }
+                }
+                else
+                {
+                    LimitPlayerMovement(character, collisionInfo);
+                }
+            }
+            it2++;
+        }
+        it++;
+    }
+
+}
+
+CollisionInfo PlatformerCollision::GetCollisionInfo(const Vector3& pos_, const PlatformerCollision& other_, const Vector3& posOther_)
+{
+    CollisionInfo collisionInfo;
+
+    Vector2 p(pos_.x + pivot.x * size.x, pos_.y + pivot.y * size.y);
+    Vector2 p2(posOther_.x + other_.pivot.x * other_.size.x, posOther_.y + other_.pivot.y * other_.size.y);
+
+    if (((p.x + size.x) > p2.x && (p2.y + other_.size.y) <= p.y)
+        || p.x <= (p2.x + other_.size.x) || p.y > (p2.y + other_.size.y)
+        || (p.y + size.y) <= p2.y)
+    {
+        collisionInfo.hasCollided = true;
+
+        if ((p.x + size.x) > p2.x && ((p2.x+other_.size.x)> (p.x + size.x)))
+        {
+            // bumped into other_ from the left side
+            collisionInfo.collisionSide[0] = true;
+        }
+        else
+        {
+            collisionInfo.collisionSide[0] = false;
+        }
+        if (p.x <= (p2.x + other_.size.x) && p.x>=p2.x)
+        {
+            // bumped into other_ form the right side 
+            collisionInfo.collisionSide[1] = true;
+        }
+        else
+        {
+            collisionInfo.collisionSide[1] = false;
+        }
+        if (p.y > (p2.y + other_.size.y))
+        {
+            // bumped into other_ from the bottom (ex: jumping)
+            collisionInfo.collisionSide[2] = true;
+        }
+        else
+        {
+            collisionInfo.collisionSide[2] = false;
+        }
+        if ((p.y + size.y) <= p2.y)
+        {
+            // standing on the other_
+            collisionInfo.collisionSide[3] = true;
+        }
+        else
+        {
+            collisionInfo.collisionSide[3] = false;
+        }
+    }
+    else 
+    {
+        collisionInfo.hasCollided = false;
+        for (auto& col : collisionInfo.collisionSide)
+        {
+            col = false;
+        }
+    }
+
+    return collisionInfo;
+}
+
+void PlatformerCollisionSystem::LimitPlayerMovement(PlatformerCharacter& character_, CollisionInfo info_)
+{
+    character_.canGoRight = !info_.collisionSide[0];
+    character_.canGoLeft = !info_.collisionSide[1];
+    character_.canGoUp = !info_.collisionSide[2];
+    character_.canGoDown = !info_.collisionSide[3];
+}

--- a/source/dagger/gameplay/platformer/platformer_collision.h
+++ b/source/dagger/gameplay/platformer/platformer_collision.h
@@ -23,7 +23,7 @@ struct PlatformerCollision
     
     // player, terrain, enemies, traps, collectables, weapons
     // For player it would be: false, true, true, true, ???, false
-    std::array<Bool, 6> collidesWith { true, true, true, true, true, false };
+    StaticArray<Bool, 6> collidesWith { true, true, true, true, true, false };
 
     CollisionInfo GetCollisionInfo(const Vector3& pos_, const PlatformerCollision& other_, const Vector3& posOther_);
 

--- a/source/dagger/gameplay/platformer/platformer_collision.h
+++ b/source/dagger/gameplay/platformer/platformer_collision.h
@@ -1,0 +1,44 @@
+#pragma once
+#include "core/system.h"
+#include "core/core.h"
+#include <array>
+
+#include "gameplay/platformer/platformer_controller.h"
+
+using namespace dagger;
+using namespace platformer;
+
+struct CollisionInfo
+{
+    Bool hasCollided{ false };
+    // 0: right | 1: left | 2: top  |  3: down
+    std::array<Bool, 4> collisionSide{ false, false,false,false };
+};
+
+struct PlatformerCollision
+{
+    UInt8 entityType = 0;
+    Vector2 size;
+    Vector2 pivot{ -0.5f, -0.5f };
+    
+    // player, terrain, enemies, traps, collectables, weapons
+    // For player it would be: false, true, true, true, ???, false
+    std::array<Bool, 6> collidesWith { true, true, true, true, true, false };
+
+    CollisionInfo GetCollisionInfo(const Vector3& pos_, const PlatformerCollision& other_, const Vector3& posOther_);
+
+};
+
+class PlatformerCollisionSystem : public System
+{
+public:
+    UInt8 playerID{ 0 };
+    UInt8 terrainID{ 1 };
+    UInt8 enemyID{ 2 };
+
+    inline String SystemName() { return "Platformer Collisions System"; }
+
+    void Run() override;
+
+    void LimitPlayerMovement(PlatformerCharacter& character_, CollisionInfo info_);
+};

--- a/source/dagger/gameplay/platformer/platformer_controller.h
+++ b/source/dagger/gameplay/platformer/platformer_controller.h
@@ -10,11 +10,20 @@ namespace platformer
 {
 	struct PlatformerCharacter
 	{
-		bool isRolling{ false };
-		bool isJumping{ false };
-		bool reachedMax{ false };
-		bool turningDuringJump{ false };
-		bool runningJump{ false };
+		UInt8 id{ 0 };
+
+		Bool isRolling{ false };
+		Bool isJumping{ false };
+		Bool reachedMax{ false };
+		Bool turningDuringJump{ false };
+		Bool runningJump{ false };
+
+		Bool canGoRight{ true };
+		Bool canGoLeft{ true };
+		Bool canGoUp{ true };
+		Bool canGoDown{ true };
+
+		Float32 currentElevation{ 0.0f };
 
 		Float32 rollingSpeed{ 25.0f };
 		Float32 rollingTime{ 0.75f };


### PR DESCRIPTION
This custom collision system prevents the players from colliding into each other (currently not working for jumping on the objects), the system first checks if the collision happened and remembers all the sides from which the collision happened. Each collision component contains information which tells us if we should take the collision between two entities (collidesWith) based on the entityType attribute. Currently both players have entityType=0 for testing purposes. In the future distinction between the classes (player, enemy, collectable) which is remebered in the entityType will be most likely controlled by enum