### PR TITLE
Team/morning afternoon/feature/game logic system

### DIFF
--- a/data/input-contexts/ASDW_circular.json
+++ b/data/input-contexts/ASDW_circular.json
@@ -33,6 +33,11 @@
       "event": "Released"
     },
     {
+      "command-name": "restart",
+      "trigger": "KeyY",
+      "event": "Released"
+    },
+    {
       "command-name": "use",
       "trigger": "KeyE"
     }

--- a/meson.build
+++ b/meson.build
@@ -44,6 +44,7 @@ sources = [
     'source/dagger/core/engine.cpp',
     'source/dagger/core/game.cpp',
     'source/dagger/gameplay/common/jiggle.cpp',
+    'source/dagger/gameplay/common/particles.cpp',
     'source/dagger/gameplay/common/simple_collisions.cpp',
     'source/dagger/gameplay/ping_pong/ping_pong_main.cpp',
     'source/dagger/gameplay/ping_pong/pingpong_ball.cpp',

--- a/source/dagger/core/graphics/text.cpp
+++ b/source/dagger/core/graphics/text.cpp
@@ -9,6 +9,7 @@ using namespace dagger;
 void Text::Set(String font_, String message_, Vector3 pos_)
 {
 	font = font_;
+	position=pos_;
 
 	auto& registry = Engine::Registry();
 
@@ -17,6 +18,7 @@ void Text::Set(String font_, String message_, Vector3 pos_)
 	if (entities.size() > 0)
 	{
 		registry.remove(entities.begin(), entities.end());
+		registry.destroy(entities.begin(), entities.end());
 		entities.clear();
 	}
 
@@ -47,5 +49,6 @@ void Text::Set(String font_, String message_, Vector3 pos_)
 		AssignSprite(sprite, spritesheet);
 
 		positionX += (int)(spritesheet->frame.size.x * spacing);
+		entities.push_back(entity);
 	}
 }

--- a/source/dagger/core/graphics/text.cpp
+++ b/source/dagger/core/graphics/text.cpp
@@ -47,5 +47,6 @@ void Text::Set(String font_, String message_, Vector3 pos_)
 		AssignSprite(sprite, spritesheet);
 
 		positionX += (int)(spritesheet->frame.size.x * spacing);
+		entities.push_back(entity);
 	}
 }

--- a/source/dagger/gameplay/common/particles.cpp
+++ b/source/dagger/gameplay/common/particles.cpp
@@ -1,0 +1,122 @@
+#include "particles.h"
+#include "core/engine.h"
+#include "core/graphics/sprite.h"
+#include "core/game/transforms.h"
+
+#include <algorithm>
+#include <execution>
+
+using namespace dagger;
+using namespace common_res;
+
+void ParticleSystem::SetupParticleSystem(Entity entity_, const ParticleSpawnerSettings& settings_)
+{
+    auto& reg = Engine::Registry();
+    auto& particleSys = reg.emplace<ParticleSpawner>(entity_);
+    particleSys.settings = settings_;
+}
+
+Float32 particle_lerp(Float32 a, Float32 b, Float32 f)
+{
+    return a + f * (b - a);
+}
+
+// get rand float value from 0 to 1
+Float32 particle_getRand()
+{
+    return ((double) rand() / (RAND_MAX));
+}
+
+void ParticleSystem::CreateParticle(const ParticleSpawnerSettings& settings_, Vector3 pos_)
+{
+    auto& reg = Engine::Registry();
+    auto entity = reg.create();
+    
+    auto& sprite = reg.emplace<Sprite>(entity);
+    AssignSprite(sprite, settings_.pSpriteName);
+    sprite.size = settings_.pSize;
+
+    Vector4 randColorVal;
+    randColorVal.r = particle_lerp(settings_.pColorMin.r, settings_.pColorMax.r, particle_getRand());
+    randColorVal.g = particle_lerp(settings_.pColorMin.g, settings_.pColorMax.g, particle_getRand());
+    randColorVal.b = particle_lerp(settings_.pColorMin.b, settings_.pColorMax.b, particle_getRand());
+    randColorVal.a = particle_lerp(settings_.pColorMin.a, settings_.pColorMax.a, particle_getRand());
+    sprite.color = randColorVal;
+
+    auto& transform = reg.emplace<Transform>(entity);
+    transform.position = pos_;
+
+    auto& particle = reg.emplace<Particle>(entity);
+    
+    Vector2 randSpeedVal;
+    randSpeedVal.x = particle_lerp(settings_.pSpeedMin.x, settings_.pSpeedMax.x, particle_getRand());
+    randSpeedVal.y = particle_lerp(settings_.pSpeedMin.y, settings_.pSpeedMax.y, particle_getRand());
+    particle.positionSpeed = {randSpeedVal.x, randSpeedVal.y, 0.f};
+
+    particle.colorSpeed = {0.f,0.f,0.f,-0.01f};
+
+    Float32 randAddition = 0.1f * (1 - 2 * (rand() % 2));
+    particle.scaleSpeed = settings_.pSize * randAddition;
+}
+
+void ParticleSystem::Run()
+{
+    // update all particle generators
+    {
+        auto particles = Engine::Registry().view<ParticleSpawner, Transform>();
+
+        for (auto& entity : particles)
+        {
+            auto& particleSys_ = particles.get<ParticleSpawner>(entity);
+            auto& t = particles.get<Transform>(entity);
+            if (particleSys_.active)
+            {
+                particleSys_.timer -= Engine::DeltaTime();
+                if (particleSys_.timer < 0)
+                {
+                    particleSys_.timer = particleSys_.settings.timeToNewParticle;
+
+                    CreateParticle(particleSys_.settings, t.position);
+                }
+            }
+        }
+    }
+
+    // update all particles
+    Engine::Registry().view<Particle, Transform, Sprite>().each([&](Particle& particle_, Transform& transform_, Sprite& sprite_)
+    {
+        if (particle_.timeOfLiving > 0)
+        {
+            particle_.timeOfLiving -= Engine::DeltaTime();
+            transform_.position += particle_.positionSpeed;
+            sprite_.size += particle_.scaleSpeed;
+            // might need to set color bounds
+            sprite_.color += particle_.colorSpeed;
+        }
+    });
+}
+
+void ParticleSystem::SpinUp()
+{
+    Engine::Dispatcher().sink<NextFrame>().connect<&ParticleSystem::OnEndOfFrame>(this);
+}
+
+void ParticleSystem::WindDown()
+{
+    Engine::Dispatcher().sink<NextFrame>().disconnect<&ParticleSystem::OnEndOfFrame>(this);
+}
+
+void ParticleSystem::OnEndOfFrame()
+{
+    auto particles = Engine::Registry().view<Particle>();
+
+    for (auto& entity : particles)
+    {
+        auto& p = particles.get<Particle>(entity);
+        if (p.timeOfLiving <= 0)
+        {
+            Engine::Registry().remove_all(entity);
+        }
+    }
+}
+

--- a/source/dagger/gameplay/common/particles.cpp
+++ b/source/dagger/gameplay/common/particles.cpp
@@ -16,11 +16,6 @@ void ParticleSystem::SetupParticleSystem(Entity entity_, const ParticleSpawnerSe
     particleSys.settings = settings_;
 }
 
-Float32 particle_lerp(Float32 a, Float32 b, Float32 f)
-{
-    return a + f * (b - a);
-}
-
 // get rand float value from 0 to 1
 Float32 particle_getRand()
 {
@@ -37,10 +32,10 @@ void ParticleSystem::CreateParticle(const ParticleSpawnerSettings& settings_, Ve
     sprite.size = settings_.pSize;
 
     Vector4 randColorVal;
-    randColorVal.r = particle_lerp(settings_.pColorMin.r, settings_.pColorMax.r, particle_getRand());
-    randColorVal.g = particle_lerp(settings_.pColorMin.g, settings_.pColorMax.g, particle_getRand());
-    randColorVal.b = particle_lerp(settings_.pColorMin.b, settings_.pColorMax.b, particle_getRand());
-    randColorVal.a = particle_lerp(settings_.pColorMin.a, settings_.pColorMax.a, particle_getRand());
+    randColorVal.r = glm::mix(settings_.pColorMin.r, settings_.pColorMax.r, particle_getRand());
+    randColorVal.g = glm::mix(settings_.pColorMin.g, settings_.pColorMax.g, particle_getRand());
+    randColorVal.b = glm::mix(settings_.pColorMin.b, settings_.pColorMax.b, particle_getRand());
+    randColorVal.a = glm::mix(settings_.pColorMin.a, settings_.pColorMax.a, particle_getRand());
     sprite.color = randColorVal;
 
     auto& transform = reg.emplace<Transform>(entity);
@@ -49,8 +44,8 @@ void ParticleSystem::CreateParticle(const ParticleSpawnerSettings& settings_, Ve
     auto& particle = reg.emplace<Particle>(entity);
     
     Vector2 randSpeedVal;
-    randSpeedVal.x = particle_lerp(settings_.pSpeedMin.x, settings_.pSpeedMax.x, particle_getRand());
-    randSpeedVal.y = particle_lerp(settings_.pSpeedMin.y, settings_.pSpeedMax.y, particle_getRand());
+    randSpeedVal.x = glm::mix(settings_.pSpeedMin.x, settings_.pSpeedMax.x, particle_getRand());
+    randSpeedVal.y = glm::mix(settings_.pSpeedMin.y, settings_.pSpeedMax.y, particle_getRand());
     particle.positionSpeed = {randSpeedVal.x, randSpeedVal.y, 0.f};
 
     particle.colorSpeed = {0.f,0.f,0.f,-0.01f};
@@ -92,6 +87,7 @@ void ParticleSystem::Run()
             sprite_.size += particle_.scaleSpeed;
             // might need to set color bounds
             sprite_.color += particle_.colorSpeed;
+            // sprite_.color = glm::clamp(sprite_.color + particle_.colorSpeed, { 0, 0, 0, 0 }, { 1, 1, 1, 1 });
         }
     });
 }

--- a/source/dagger/gameplay/common/particles.h
+++ b/source/dagger/gameplay/common/particles.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include "core/system.h"
+#include "core/core.h"
+    
+using namespace dagger;
+
+namespace common_res
+{
+
+struct Particle
+{
+    Vector2 scaleSpeed;
+    Vector3 positionSpeed;
+    Vector4 colorSpeed;
+    Float32 timeOfLiving = 1.f;
+};
+
+struct ParticleSpawnerSettings
+{
+    Float32 timeToNewParticle = 1.f;
+    Vector2 pSize;
+    Vector2 pSpeedMin;
+    Vector2 pSpeedMax;
+    ColorRGBA pColorMin{ 1.0f, 1.0f, 1.0f, 1.0f };
+    ColorRGBA pColorMax{ 1.0f, 1.0f, 1.0f, 1.0f };
+    String pSpriteName;
+
+    void Setup(Float32 timeToNewParticle_, Vector2 pSize_, Vector2 pSpeedMin_, Vector2 pSpeedMax_, 
+                ColorRGBA pColorMin_ = { 1.0f, 1.0f, 1.0f, 1.0f }, ColorRGBA pColorMax_ = { 1.0f, 1.0f, 1.0f, 1.0f }, 
+                String pSpriteName_ = "EmptyWhitePixel")
+    {
+        timeToNewParticle = timeToNewParticle_;
+        pSize = pSize_;
+        pSpeedMin = pSpeedMin_;
+        pSpeedMax = pSpeedMax_;
+        pSpriteName = pSpriteName_;
+        pColorMin = pColorMin_;
+        pColorMax = pColorMax_;
+    }
+};
+
+class ParticleSystem
+    : public System
+{
+    inline String SystemName() { return "Particle System"; }
+
+    void SpinUp() override;
+    void Run() override;
+    void WindDown() override;
+
+    struct ParticleSpawner
+    {
+        Bool active = true;
+        Float32 timer = 0.f;
+
+        ParticleSpawnerSettings settings;
+    };
+
+public:
+    static void SetupParticleSystem(Entity entity_, const ParticleSpawnerSettings& settings_);
+
+private:
+    void OnEndOfFrame();
+
+    void CreateParticle(const ParticleSpawnerSettings& settings_, Vector3 pos_);
+};
+}

--- a/source/dagger/gameplay/plight/plight.cpp
+++ b/source/dagger/gameplay/plight/plight.cpp
@@ -180,7 +180,9 @@ void plight::ResetCharacters()
             character.sprite.scale.x = -1;
         }
 
-        
+        character.character.dashing = false;
+        character.character.running = false;
+        character.character.resting = false;
         
         
     }

--- a/source/dagger/gameplay/plight/plight.cpp
+++ b/source/dagger/gameplay/plight/plight.cpp
@@ -309,11 +309,6 @@ void plight::SetupWorld_AimingSystem(Engine& engine_)
 {
     auto entity = Engine::Registry().create();
     auto& pgInfo = Engine::Registry().emplace<PlightGameInfo>(entity);
-    pgInfo.newGameMessage = Engine::Registry().create();
-    auto& text = Engine::Registry().emplace<Text>(pgInfo.newGameMessage);
-    text.spacing = 0.6f;
-    text.position.y = 150;
-    text.position.x = 50;
 
     auto mainChar = PlightCharacter::Create("asdw_circular", { 1, 1, 1 }, { -356, 32 });
     mainChar.crosshair.startAngle = 0.f;

--- a/source/dagger/gameplay/plight/plight.cpp
+++ b/source/dagger/gameplay/plight/plight.cpp
@@ -10,6 +10,7 @@
 #include "core/graphics/window.h"
 #include "core/game/transforms.h"
 #include "core/graphics/sprite_render.h"
+#include "core/graphics/text.h"
 #include "core/graphics/textures.h"
 #include "core/graphics/animations.h"
 #include "core/graphics/gui.h"
@@ -82,6 +83,7 @@ struct PlightCharacter
         chr.col.size.y = 16;
 
         chr.transform.position = { position_, 2.0f };
+        chr.character.startPosition = position_;
 
         AssignSprite(chr.sprite, "spritesheets:dungeon:big_demon_idle_anim:1");
         AnimatorPlay(chr.animator, "Plight:big_deamon:IDLE");
@@ -142,6 +144,46 @@ void Plight::WorldSetup(Engine &engine_)
 
 void plight::SetupWorld(Engine &engine_)
 {
+}
+
+void plight::ResetCharacters()
+{
+    auto view = Engine::Registry().view<PlightCharacterController>();
+    for (auto entity : view) {
+        auto character = PlightCharacter::Get(entity);
+        character.cstats.currentHealth = character.cstats.maxHealth;
+        character.cstats.currentStamina = character.cstats.maxStamina;
+        character.transform.position.x = character.character.startPosition.x;
+        character.transform.position.y = character.character.startPosition.y;
+
+        auto& currentHealthBar = Engine::Registry().get<Sprite>(character.cstats.currentHealthBar);
+        auto& currentStaminaBar = Engine::Registry().get<Sprite>(character.cstats.currentStaminaBar);
+        auto& backgroundHealthBar = Engine::Registry().get<Sprite>(character.cstats.backgroundHealthBar);
+        auto& backgroundStaminaBar = Engine::Registry().get<Sprite>(character.cstats.backgroundStaminaBar);
+
+        currentHealthBar.size.x = 50;
+        currentStaminaBar.size.x = 50;
+        currentHealthBar.position.x = backgroundHealthBar.position.x;
+        currentStaminaBar.position.x = backgroundStaminaBar.position.x;
+        character.cstats.healthBarOffset = 0.f;
+        character.cstats.staminaBarOffset = 0.f;
+
+        auto& crosshairSprite = Engine::Registry().get<Sprite>(character.crosshair.crosshairSprite);
+        crosshairSprite.position.x = character.transform.position.x + character.crosshair.playerDistance;
+        crosshairSprite.position.y = character.transform.position.y;
+        crosshairSprite.position.z = character.transform.position.z;
+
+        character.crosshair.angle = character.crosshair.startAngle;
+        if (character.crosshair.angle > 0.f) {
+            auto& crosshairSprite = Engine::Registry().get<Sprite>(character.crosshair.crosshairSprite);
+            crosshairSprite.position.x -= character.crosshair.playerDistance * 2;
+            character.sprite.scale.x = -1;
+        }
+
+        
+        
+        
+    }
 }
 
 void setUpBackground(Engine& engine_) {
@@ -265,9 +307,16 @@ void plight::SetupWorld_CombatSystem(Engine& engine_){
 
 void plight::SetupWorld_AimingSystem(Engine& engine_)
 {
-    //setUpBackground(engine_);
+    auto entity = Engine::Registry().create();
+    auto& pgInfo = Engine::Registry().emplace<PlightGameInfo>(entity);
+    pgInfo.newGameMessage = Engine::Registry().create();
+    auto& text = Engine::Registry().emplace<Text>(pgInfo.newGameMessage);
+    text.spacing = 0.6f;
+    text.position.y = 150;
+    text.position.x = 50;
 
     auto mainChar = PlightCharacter::Create("asdw_circular", { 1, 1, 1 }, { -356, 32 });
+    mainChar.crosshair.startAngle = 0.f;
 
     auto backgroundHealthBar1 = Engine::Registry().create();
     auto currentHealthBar1 = Engine::Registry().create();
@@ -314,6 +363,7 @@ void plight::SetupWorld_AimingSystem(Engine& engine_)
 
     auto sndChar = PlightCharacter::Create("arrows_circular", { 1, 0, 0 }, { 356, 32 });
     sndChar.crosshair.angle = M_PI;
+    sndChar.crosshair.startAngle = M_PI;
     auto& crosshairSprite = Engine::Registry().get<Sprite>(sndChar.crosshair.crosshairSprite);
     crosshairSprite.position.x -= sndChar.crosshair.playerDistance * 2;
 

--- a/source/dagger/gameplay/plight/plight.cpp
+++ b/source/dagger/gameplay/plight/plight.cpp
@@ -24,6 +24,7 @@
 #include "gameplay/plight/plight_aiming.h"
 #include "gameplay/plight/plight_projectiles.h"
 #include "gameplay/plight/tilemaps.h"
+#include "gameplay/plight/plight_game_logic.h"
 
 
 
@@ -119,6 +120,7 @@ void Plight::GameplaySystemsSetup(Engine &engine_)
     engine_.AddSystem<PlightAimingSystem>();
     engine_.AddSystem<TilemapSystem>();
     engine_.AddSystem<ProjectileSystem>();
+    engine_.AddSystem<PlightGameLogicSystem>();
 }
 
 void Plight::WorldSetup(Engine &engine_)

--- a/source/dagger/gameplay/plight/plight.h
+++ b/source/dagger/gameplay/plight/plight.h
@@ -10,6 +10,7 @@ using namespace dagger;
 namespace plight
 {
     void SetupWorld(Engine& engine_);
+    void ResetCharacters();
     void SetupWorld_test1(Engine& engine_);
     void SetupWorld_CombatSystem(Engine& engine_);
     void SetupWorld_AimingSystem(Engine& engine_);

--- a/source/dagger/gameplay/plight/plight_aiming.h
+++ b/source/dagger/gameplay/plight/plight_aiming.h
@@ -13,6 +13,8 @@ namespace plight {
         Float32 playerDistance{ 20.f };
 
         Float32 rotationSpeed{ 5.f };
+
+        Float32 startAngle{ 0.f };
     };
 
     class PlightAimingSystem : public System

--- a/source/dagger/gameplay/plight/plight_controller.h
+++ b/source/dagger/gameplay/plight/plight_controller.h
@@ -29,6 +29,9 @@ namespace plight
 		Float32 currentDashingTime{ 0.f };
 		Float32 doubleTapDurationWindow{ 0.25f };
 		Float32 currentDoubleTapDuration{ 0.f };
+
+		//used for reseting characters
+		Vector2 startPosition = { 0.f,0.f };
 	};
 
 	class PlightControllerSystem

--- a/source/dagger/gameplay/plight/plight_controller_fsm.cpp
+++ b/source/dagger/gameplay/plight/plight_controller_fsm.cpp
@@ -179,7 +179,7 @@ void PlightCharacterControllerFSM::Dashing::Run(PlightCharacterControllerFSM::St
 {
     auto&& [sprite, character, cstats, crosshair, transform] = Engine::Registry().get<Sprite,PlightCharacterController, CombatStats, PlightCrosshair, Transform>(state_.entity);
 
-    if (cstats.currentStamina < STAMINA_FOR_DASHING_FRAME)
+    if (!character.dashing || cstats.currentStamina < STAMINA_FOR_DASHING_FRAME)
     {
         GoTo(PlightCharacterStates::Idle, state_);
     }

--- a/source/dagger/gameplay/plight/plight_game_logic.cpp
+++ b/source/dagger/gameplay/plight/plight_game_logic.cpp
@@ -1,0 +1,46 @@
+#include "plight_game_logic.h"
+
+#include "core/engine.h"
+#include "core/input/inputs.h"
+#include "core/game/transforms.h"
+
+#include "gameplay/plight/plight.h"
+
+using namespace dagger;
+using namespace plight;
+
+void PlightGameLogicSystem::SpinUp()
+{
+    Engine::Dispatcher().sink<NextFrame>().connect<&PlightGameLogicSystem::OnEndOfFrame>(this);
+}
+
+void PlightGameLogicSystem::WindDown()
+{
+    Engine::Dispatcher().sink<NextFrame>().disconnect<&PlightGameLogicSystem::OnEndOfFrame>(this);
+}
+
+void PlightGameLogicSystem::Run()
+{
+    
+        auto view = Engine::Registry().view<InputReceiver>();
+        for (auto entity : view)
+        {
+            auto& input = view.get<InputReceiver>(entity);
+            if (EPSILON_NOT_ZERO(input.Get("restart"))) {
+                m_Restart = true;
+            }
+        }
+    
+}
+
+void PlightGameLogicSystem::OnEndOfFrame()
+{
+    if (m_Restart)
+    {
+        m_Restart = false;
+        Engine::Registry().clear();
+
+        plight::SetupTilemaps();
+        plight::SetupWorld_AimingSystem(Engine::Instance());
+    }
+}

--- a/source/dagger/gameplay/plight/plight_game_logic.h
+++ b/source/dagger/gameplay/plight/plight_game_logic.h
@@ -7,11 +7,21 @@ using namespace dagger;
 
 namespace plight
 {
+    struct PlightGameInfo {
+        bool newGame = true;
+        bool displayingMessage = false;
+        String newGameMessageString = "New Game!";
+        Entity newGameMessage;
+
+        Float32 newGameMessageDuration = 2.f;
+        Float32 currentMessageDuration = 0.f;
+    };
    
     class PlightGameLogicSystem
         : public System
     {
         bool m_Restart = false;
+       
 
     public:
         inline String SystemName() { return "Plight Game Logic System System"; }

--- a/source/dagger/gameplay/plight/plight_game_logic.h
+++ b/source/dagger/gameplay/plight/plight_game_logic.h
@@ -10,7 +10,10 @@ namespace plight
     struct PlightGameInfo {
         bool newGame = true;
         bool displayingMessage = false;
-        String newGameMessageString = "New Game!";
+        bool displayingMessage2 = false;
+        String newGameMessageString1 = "New Game!";
+        String newGameMessageString2 = "Battle!";
+
         Entity newGameMessage;
 
         Float32 newGameMessageDuration = 2.f;

--- a/source/dagger/gameplay/plight/plight_game_logic.h
+++ b/source/dagger/gameplay/plight/plight_game_logic.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "core/system.h"
+#include "core/core.h"
+
+using namespace dagger;
+
+namespace plight
+{
+   
+    class PlightGameLogicSystem
+        : public System
+    {
+        bool m_Restart = false;
+
+    public:
+        inline String SystemName() { return "Plight Game Logic System System"; }
+
+        void SpinUp() override;
+        void WindDown() override;
+        void Run() override;
+
+    private:
+        void OnEndOfFrame();
+
+    };
+}

--- a/source/dagger/gameplay/racing/racing_main.cpp
+++ b/source/dagger/gameplay/racing/racing_main.cpp
@@ -10,6 +10,7 @@
 #include "core/game/transforms.h"
 
 #include "gameplay/common/simple_collisions.h"
+#include "gameplay/common/particles.h"
 
 #include "gameplay/racing/racing_game_logic.h"
 #include "gameplay/racing/racing_player_car.h"
@@ -24,6 +25,7 @@ void RacingGame::GameplaySystemsSetup(Engine &engine_)
     engine_.AddSystem<RacingCarSystem>();
     engine_.AddSystem<RacingCollisionsLogicSystem>();
     engine_.AddSystem<SimpleCollisionsSystem>();
+    engine_.AddSystem<common_res::ParticleSystem>();
 }
 
 void RacingGame::WorldSetup(Engine &engine_)
@@ -110,6 +112,11 @@ void racing_game::SetupWorld(Engine &engine_)
 
         auto& col = reg.emplace<SimpleCollision>(entity);
         col.size = sprite.size;
+
+        common_res::ParticleSpawnerSettings settings;
+        settings.Setup(0.05f, {4.f, 4.f}, {-0.2f, -1.4f}, {0.2f, -0.6f}, 
+                        {0.6f,0.6f,0.6f,1}, {1,1,1,1}, "EmptyWhitePixel");
+        common_res::ParticleSystem::SetupParticleSystem(entity, settings);
     }
 
     // collisions for road bounds
@@ -133,5 +140,10 @@ void racing_game::SetupWorld(Engine &engine_)
 
         auto& col = reg.emplace<SimpleCollision>(entity);
         col.size = sprite.size;
+
+        common_res::ParticleSpawnerSettings settings;
+        settings.Setup(0.1f, {4.f, 4.f}, {-0.2f, 0.4f}, {0.2f, 1.2f}, 
+                        {0.6f,0.6f,0.6f,1}, {1,1,1,1}, "EmptyWhitePixel");
+        common_res::ParticleSystem::SetupParticleSystem(entity, settings);
     }
 }

--- a/source/dagger/gameplay/tiles_example/tiles_example_main.cpp
+++ b/source/dagger/gameplay/tiles_example/tiles_example_main.cpp
@@ -52,4 +52,6 @@ void TilesExampleMain::WorldSetup(Engine& engine_)
     auto& text = reg.emplace<Text>(ui);
     text.spacing = 0.6f;
     text.Set("pixel-font", "hello world");
+    text.Set("pixel-font", "new text",{10,-200,0});
+
 }

--- a/source/dagger/main.cpp
+++ b/source/dagger/main.cpp
@@ -12,6 +12,6 @@ int main(int argc_, char** argv_)
 //	return engine.Run<tiles_example::TilesExampleMain>();
 //	return engine.Run<team_game::TeamGame>();
 //	return engine.Run<ping_pong::PingPongGame>();
-//	return engine.Run<racing_game::RacingGame>();
-	return engine.Run<platformer::Platformer>();
+	return engine.Run<racing_game::RacingGame>();
+//	return engine.Run<platformer::Platformer>();
 }


### PR DESCRIPTION
Implemented game logic system which restarts the game on a key press ( Y key ) and also displays some text to indicate the new game starting. 
The restart game is done by resetting character settings and deleting all currently active projectiles instead of clearing the engine registry because I had problems with nullptr exceptions when using the Engine::Registry().clear method.
So basically we are using same components , but the fields are reset to default values.