### PR TITLE
Added UI sprites and refreshed text rendering

### DIFF
--- a/data/shaders/standard.vs.glsl
+++ b/data/shaders/standard.vs.glsl
@@ -12,6 +12,7 @@ layout (location = 6) in vec2 ai_QuadPivot;
 layout (location = 7) in vec4 ai_QuadColor;
 layout (location = 8) in vec2 ai_Scale;
 layout (location = 9) in float ai_Rotation;
+layout (location = 10) in float ai_IsUI;
 
 uniform mat4 u_Projection;
 uniform mat4 u_Viewport;
@@ -42,6 +43,10 @@ void main()
 		cosRotation * recenteredVertexPosition.x - sinRotation * recenteredVertexPosition.y, 
 		sinRotation * recenteredVertexPosition.x + cosRotation * recenteredVertexPosition.y);
 
-	gl_Position = u_Projection * u_Viewport * u_Camera * 
-		vec4(rotatedVertexPosition + ai_QuadPosition.xy, -ai_QuadPosition.z, 1.0f);
+	vec4 position = vec4(rotatedVertexPosition + ai_QuadPosition.xy, -ai_QuadPosition.z, 1.0f);
+
+	if(ai_IsUI < 0.5f)
+		gl_Position = u_Projection * u_Viewport * u_Camera * position;
+	else
+		gl_Position = u_Projection * u_Viewport * position;
 }

--- a/source/dagger/core/graphics/sprite.h
+++ b/source/dagger/core/graphics/sprite.h
@@ -30,6 +30,17 @@ namespace dagger
 		ColorRGBA color{ 1.0f, 1.0f, 1.0f, 1.0f };		// 4
 		Vector2 scale{ 1.0f, 1.0f };					// 2
 		Float32 rotation{ 0.0f };						// 1
+		Float32 isUI{ 0.0f };							// 1
+
+		inline void UseAsUI()
+		{
+			isUI = 1.0f;
+		}
+
+		inline void UseInWorld()
+		{
+			isUI = 0.0f;
+		}
 	};
 
 	struct Sprite : public SpriteData

--- a/source/dagger/core/graphics/sprite_render.cpp
+++ b/source/dagger/core/graphics/sprite_render.cpp
@@ -38,7 +38,7 @@ void SpriteRenderSystem::SpinUp()
     glBindBuffer(GL_ARRAY_BUFFER, m_InstanceQuadInfoVBO);
 	glBufferData(GL_ARRAY_BUFFER, s_BufferSize, nullptr, GL_STREAM_DRAW);
 
-    const StaticArray<Pair<UInt32, UInt32>, 8> sizesAndStrides = {
+    const StaticArray<Pair<UInt32, UInt32>, 9> sizesAndStrides = {
         pair(2, 0),     // #2: sub size
         pair(2, 2),     // #3: sub origin
         pair(2, 4),     // #4: sub origin
@@ -47,6 +47,7 @@ void SpriteRenderSystem::SpinUp()
         pair(4, 11),    // #7: quad tint color
         pair(2, 15),    // #8: scale
         pair(1, 17),    // #9: rotation
+        pair(1, 18),    // #10: is UI?
     };
 
     for (UInt32 i = 0; i < sizesAndStrides.size(); i++)

--- a/source/dagger/core/graphics/text.cpp
+++ b/source/dagger/core/graphics/text.cpp
@@ -6,7 +6,7 @@
 
 using namespace dagger;
 
-void Text::Set(String font_, String message_, Vector3 pos_)
+void Text::Set(String font_, String message_, Vector3 pos_, Bool ui_)
 {
 	font = font_;
 	position=pos_;
@@ -44,8 +44,9 @@ void Text::Set(String font_, String message_, Vector3 pos_)
 		auto spritesheet = cache[letter];
 		auto entity = registry.create();
 		auto& sprite = registry.emplace<Sprite>(entity);
+
+		if (ui_) sprite.UseAsUI();
 		sprite.position = { positionX - xOffsetDueToAlign, position.y, position.z };
-		
 		AssignSprite(sprite, spritesheet);
 
 		positionX += (int)(spritesheet->frame.size.x * spacing);

--- a/source/dagger/core/graphics/text.h
+++ b/source/dagger/core/graphics/text.h
@@ -18,10 +18,5 @@ struct Text
 
 	Vector3 position;
 
-	inline void Set(String font_, String message_)
-	{
-		Set(font_, message_, { 0, 0, 0 });
-	}
-
-	void Set(String font_, String message_, Vector3 pos_);
+	void Set(String font_, String message_, Vector3 pos_ = { 0, 0, 0 }, Bool ui_ = true);
 };

--- a/source/dagger/gameplay/platformer/platformer_main.cpp
+++ b/source/dagger/gameplay/platformer/platformer_main.cpp
@@ -12,6 +12,8 @@
 #include "core/graphics/textures.h"
 #include "core/graphics/animations.h"
 #include "core/graphics/gui.h"
+#include "core/graphics/text.h"
+
 #include "tools/diagnostics.h"
 
 #include "gameplay/platformer/platformer_controller.h"
@@ -129,6 +131,13 @@ void CreateBackdrop()
 
         AssignSprite(sprite, "souls_like_knight_character:BACKGROUND:Tree");
         sprite.position = { 0, 30, 7 };
+    }
+
+    {
+        auto ui = reg.create();
+        auto& text = reg.emplace<Text>(ui);
+        text.spacing = 0.6f;
+        text.Set("pixel-font", "hello world");
     }
 }
 

--- a/source/dagger/gameplay/tiles_example/tiles_example_main.cpp
+++ b/source/dagger/gameplay/tiles_example/tiles_example_main.cpp
@@ -52,6 +52,6 @@ void TilesExampleMain::WorldSetup(Engine& engine_)
     auto& text = reg.emplace<Text>(ui);
     text.spacing = 0.6f;
     text.Set("pixel-font", "hello world");
-    text.Set("pixel-font", "new text",{10,-200,0});
+    text.Set("pixel-font", "new text", { 10,-200,0 });
 
 }

--- a/source/dagger/main.cpp
+++ b/source/dagger/main.cpp
@@ -12,6 +12,6 @@ int main(int argc_, char** argv_)
 //	return engine.Run<tiles_example::TilesExampleMain>();
 //	return engine.Run<team_game::TeamGame>();
 //	return engine.Run<ping_pong::PingPongGame>();
-	return engine.Run<racing_game::RacingGame>();
-//	return engine.Run<platformer::Platformer>();
+//	return engine.Run<racing_game::RacingGame>();
+	return engine.Run<platformer::Platformer>();
 }


### PR DESCRIPTION
To make a sprite not use the camera, use the `sprite.UseAsUI()` method. Text does this by default.